### PR TITLE
Add basic FastAPI backend and Vue frontend skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# AI Demo Project
+
+This repository contains a minimal demonstration of an Amazon intelligence toolkit. The main feature allows entering an Amazon ASIN or product URL and quickly returning structured listing information.
+
+## Backend
+- Python `FastAPI` server located in `backend/`
+- Endpoint `GET /api/scrape` accepts `asin` or `url` query parameters
+- A mock `CompetitorMonitorAgent` parses a sample HTML file and returns listing data
+
+### Running
+```bash
+pip install -r backend/requirements.txt
+uvicorn backend.main:app --reload
+```
+The backend also serves the Vue3 frontend.
+
+## Frontend
+- Minimal Vue3 app (`frontend/index.html`)
+- Allows input of ASIN or URL and displays JSON response
+
+Open `http://127.0.0.1:8000` after starting the backend to use the demo.
+
+*Note*: Due to environment restrictions, the demo uses a static sample HTML file instead of live Amazon requests.

--- a/backend/agents/competitor_monitor.py
+++ b/backend/agents/competitor_monitor.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+from bs4 import BeautifulSoup
+from dataclasses import dataclass
+import re
+from pathlib import Path
+
+@dataclass
+class ListingData:
+    title: str | None = None
+    bullets: list[str] | None = None
+    images: list[str] | None = None
+    price: str | None = None
+    brand: str | None = None
+    description: str | None = None
+
+class CompetitorMonitorAgent:
+    """Mock agent to fetch Amazon listing information."""
+
+    sample_file = Path(__file__).resolve().parent / "sample_listing.html"
+
+    def fetch_competitor_data(self, asin_or_url: str) -> ListingData:
+        """Fetch listing data. Currently reads from a sample HTML file."""
+        # In real use, you'd fetch from Amazon. For demo we read a local file.
+        html = self.sample_file.read_text(encoding="utf-8")
+        soup = BeautifulSoup(html, 'html.parser')
+        data = ListingData()
+        title_el = soup.select_one('#productTitle')
+        if title_el:
+            data.title = title_el.get_text(strip=True)
+        bullet_els = soup.select('#feature-bullets ul li')
+        if bullet_els:
+            data.bullets = [b.get_text(strip=True) for b in bullet_els]
+        img_els = soup.select('#altImages img')
+        if img_els:
+            data.images = [img.get('alt', '') for img in img_els]
+        price_el = soup.select_one('#priceblock_ourprice') or soup.select_one('#priceblock_dealprice')
+        if price_el:
+            data.price = price_el.get_text(strip=True)
+        brand_el = soup.select_one('#bylineInfo')
+        if brand_el:
+            data.brand = brand_el.get_text(strip=True)
+        desc_el = soup.select_one('#productDescription')
+        if desc_el:
+            data.description = desc_el.get_text(strip=True)
+        return data

--- a/backend/agents/sample_listing.html
+++ b/backend/agents/sample_listing.html
@@ -1,0 +1,19 @@
+<html>
+<head><title>Sample Product</title></head>
+<body>
+<span id="productTitle">Sample Product Title</span>
+<div id="bylineInfo">Sample Brand</div>
+<span id="priceblock_ourprice">$19.99</span>
+<div id="feature-bullets">
+  <ul>
+    <li>Bullet 1 content</li>
+    <li>Bullet 2 content</li>
+  </ul>
+</div>
+<div id="altImages">
+  <img src="image1.jpg" alt="Image Alt 1" />
+  <img src="image2.jpg" alt="Image Alt 2" />
+</div>
+<div id="productDescription">This is a sample description of the product.</div>
+</body>
+</html>

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,37 @@
+from fastapi import FastAPI, HTTPException, Query
+from fastapi.staticfiles import StaticFiles
+from fastapi.responses import FileResponse
+from pydantic import BaseModel
+from pathlib import Path
+
+from agents.competitor_monitor import CompetitorMonitorAgent
+
+app = FastAPI(title="Amazon Intelligence Demo")
+
+frontend_path = Path(__file__).resolve().parent.parent / 'frontend'
+app.mount('/static', StaticFiles(directory=frontend_path, html=True), name='static')
+
+
+@app.get('/')
+def index():
+    return FileResponse(frontend_path / 'index.html')
+
+agent = CompetitorMonitorAgent()
+
+class ScrapeResponse(BaseModel):
+    title: str | None = None
+    bullets: list[str] | None = None
+    images: list[str] | None = None
+    price: str | None = None
+    brand: str | None = None
+    description: str | None = None
+
+@app.get("/api/scrape", response_model=ScrapeResponse)
+def scrape(asin: str = Query(None), url: str = Query(None)):
+    if not asin and not url:
+        raise HTTPException(status_code=400, detail="ASIN or URL required")
+    try:
+        data = agent.fetch_competitor_data(asin or url)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+    return data

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+requests
+beautifulsoup4

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Amazon Intelligence Demo</title>
+    <script src="https://unpkg.com/vue@3/dist/vue.global.prod.js"></script>
+</head>
+<body>
+<div id="app">
+    <h1>Amazon Listing Scraper</h1>
+    <input v-model="input" placeholder="Enter ASIN or URL" />
+    <button @click="scrape">\u91c7\u96c6</button>
+    <pre>{{ result }}</pre>
+</div>
+<script>
+const { createApp } = Vue;
+createApp({
+    data() { return { input: '', result: {} }; },
+    methods: {
+        async scrape() {
+            const params = new URLSearchParams();
+            if (this.input.startsWith('http')) {
+                params.append('url', this.input);
+            } else {
+                params.append('asin', this.input);
+            }
+            const res = await fetch('/api/scrape?' + params.toString());
+            this.result = await res.json();
+        }
+    }
+}).mount('#app');
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- set up minimal FastAPI server to expose `/api/scrape`
- implement `CompetitorMonitorAgent` with sample HTML parsing
- create Vue3 demo page and serve it via FastAPI
- document quick start in README

## Testing
- `python3 -m py_compile backend/main.py backend/agents/competitor_monitor.py`
- `pip install -r backend/requirements.txt`
- `PYTHONPATH=backend uvicorn backend.main:app --port 8002 --log-level warning` (manual testing with curl)


------
https://chatgpt.com/codex/tasks/task_e_685283481a7883329432e325cad691e2