### PR TITLE
Implement multi-agent API endpoints and tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# AI Demo Project
+
+This repository contains a minimal demonstration of an Amazon intelligence toolkit. It exposes four mock services representing the project agents:
+CustomerServiceAgent, ListingOptimizerAgent, ReviewAnalysisAgent and CompetitorMonitorAgent. The Competitor Monitor feature accepts an ASIN or URL and returns structured listing information.
+
+## Backend
+- Python `FastAPI` server located in `backend/`
+- Endpoint `GET /api/scrape` returns mock listing data
+- Endpoint `POST /api/customer_service` returns a simple reply
+- Endpoint `POST /api/listing_optimizer` returns optimized title data
+- Endpoint `POST /api/review_analysis` returns a review summary
+
+### Running
+```bash
+pip install -r backend/requirements.txt
+uvicorn backend.main:app --reload
+```
+The backend also serves the Vue3 frontend.
+
+## Frontend
+- Vue3 app (`frontend/index.html`) provides four tabs matching the agents
+- Each tab sends a request to the corresponding API and shows the JSON reply
+
+Open `http://127.0.0.1:8000` after starting the backend to use the demo.
+
+*Note*: Due to environment restrictions, the demo uses a static sample HTML file instead of live Amazon requests.

--- a/backend/agents/competitor_monitor.py
+++ b/backend/agents/competitor_monitor.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+from bs4 import BeautifulSoup
+from dataclasses import dataclass
+import re
+from pathlib import Path
+
+@dataclass
+class ListingData:
+    title: str | None = None
+    bullets: list[str] | None = None
+    images: list[str] | None = None
+    price: str | None = None
+    brand: str | None = None
+    description: str | None = None
+
+class CompetitorMonitorAgent:
+    """Mock agent to fetch Amazon listing information."""
+
+    sample_file = Path(__file__).resolve().parent / "sample_listing.html"
+
+    def fetch_competitor_data(self, asin_or_url: str) -> ListingData:
+        """Fetch listing data. Currently reads from a sample HTML file."""
+        # In real use, you'd fetch from Amazon. For demo we read a local file.
+        html = self.sample_file.read_text(encoding="utf-8")
+        soup = BeautifulSoup(html, 'html.parser')
+        data = ListingData()
+        title_el = soup.select_one('#productTitle')
+        if title_el:
+            data.title = title_el.get_text(strip=True)
+        bullet_els = soup.select('#feature-bullets ul li')
+        if bullet_els:
+            data.bullets = [b.get_text(strip=True) for b in bullet_els]
+        img_els = soup.select('#altImages img')
+        if img_els:
+            data.images = [img.get('alt', '') for img in img_els]
+        price_el = soup.select_one('#priceblock_ourprice') or soup.select_one('#priceblock_dealprice')
+        if price_el:
+            data.price = price_el.get_text(strip=True)
+        brand_el = soup.select_one('#bylineInfo')
+        if brand_el:
+            data.brand = brand_el.get_text(strip=True)
+        desc_el = soup.select_one('#productDescription')
+        if desc_el:
+            data.description = desc_el.get_text(strip=True)
+        return data

--- a/backend/agents/customer_service.py
+++ b/backend/agents/customer_service.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+
+@dataclass
+class Reply:
+    answer: str
+    sentiment: str | None = None
+
+class CustomerServiceAgent:
+    """Mock customer service agent."""
+
+    def reply(self, question: str) -> Reply:
+        # trivial mock: echo question
+        return Reply(answer=f"Thanks for asking about '{question}'. We will get back to you soon.", sentiment="neutral")

--- a/backend/agents/listing_optimizer.py
+++ b/backend/agents/listing_optimizer.py
@@ -1,0 +1,14 @@
+from dataclasses import dataclass
+
+@dataclass
+class OptimizationResult:
+    improved_title: str
+    score: int
+    keywords: list[str]
+
+class ListingOptimizerAgent:
+    """Mock listing optimizer."""
+
+    def optimize_listing(self, title: str) -> OptimizationResult:
+        improved = title + " (Optimized)"
+        return OptimizationResult(improved_title=improved, score=80, keywords=["sample", "keyword"])

--- a/backend/agents/review_analysis.py
+++ b/backend/agents/review_analysis.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+
+@dataclass
+class ReviewSummary:
+    sentiment: str
+    top_words: list[str]
+
+class ReviewAnalysisAgent:
+    """Mock review analysis agent."""
+
+    def summarize(self, reviews: list[str]) -> ReviewSummary:
+        # naive summarization
+        return ReviewSummary(sentiment="positive", top_words=["good", "quality"])

--- a/backend/agents/sample_listing.html
+++ b/backend/agents/sample_listing.html
@@ -1,0 +1,19 @@
+<html>
+<head><title>Sample Product</title></head>
+<body>
+<span id="productTitle">Sample Product Title</span>
+<div id="bylineInfo">Sample Brand</div>
+<span id="priceblock_ourprice">$19.99</span>
+<div id="feature-bullets">
+  <ul>
+    <li>Bullet 1 content</li>
+    <li>Bullet 2 content</li>
+  </ul>
+</div>
+<div id="altImages">
+  <img src="image1.jpg" alt="Image Alt 1" />
+  <img src="image2.jpg" alt="Image Alt 2" />
+</div>
+<div id="productDescription">This is a sample description of the product.</div>
+</body>
+</html>

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,83 @@
+from fastapi import FastAPI, HTTPException, Query
+from fastapi.staticfiles import StaticFiles
+from fastapi.responses import FileResponse
+from pydantic import BaseModel
+from pathlib import Path
+
+from agents.competitor_monitor import CompetitorMonitorAgent
+from agents.customer_service import CustomerServiceAgent
+from agents.listing_optimizer import ListingOptimizerAgent
+from agents.review_analysis import ReviewAnalysisAgent
+
+app = FastAPI(title="Amazon Intelligence Demo")
+
+frontend_path = Path(__file__).resolve().parent.parent / 'frontend'
+app.mount('/static', StaticFiles(directory=frontend_path, html=True), name='static')
+
+
+@app.get('/')
+def index():
+    return FileResponse(frontend_path / 'index.html')
+
+competitor_agent = CompetitorMonitorAgent()
+customer_agent = CustomerServiceAgent()
+optimizer_agent = ListingOptimizerAgent()
+review_agent = ReviewAnalysisAgent()
+
+class ScrapeResponse(BaseModel):
+    title: str | None = None
+    bullets: list[str] | None = None
+    images: list[str] | None = None
+    price: str | None = None
+    brand: str | None = None
+    description: str | None = None
+
+class ServiceRequest(BaseModel):
+    question: str
+
+class ServiceReply(BaseModel):
+    answer: str
+    sentiment: str | None = None
+
+class OptimizeRequest(BaseModel):
+    title: str
+
+class OptimizeResponse(BaseModel):
+    improved_title: str
+    score: int
+    keywords: list[str]
+
+class ReviewRequest(BaseModel):
+    reviews: list[str]
+
+class ReviewResponse(BaseModel):
+    sentiment: str
+    top_words: list[str]
+
+@app.get("/api/scrape", response_model=ScrapeResponse)
+def scrape(asin: str = Query(None), url: str = Query(None)):
+    if not asin and not url:
+        raise HTTPException(status_code=400, detail="ASIN or URL required")
+    try:
+        data = competitor_agent.fetch_competitor_data(asin or url)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+    return data
+
+
+@app.post("/api/customer_service", response_model=ServiceReply)
+def customer_service(req: ServiceRequest):
+    reply = customer_agent.reply(req.question)
+    return reply
+
+
+@app.post("/api/listing_optimizer", response_model=OptimizeResponse)
+def listing_optimizer(req: OptimizeRequest):
+    result = optimizer_agent.optimize_listing(req.title)
+    return result
+
+
+@app.post("/api/review_analysis", response_model=ReviewResponse)
+def review_analysis(req: ReviewRequest):
+    summary = review_agent.summarize(req.reviews)
+    return summary

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+requests
+beautifulsoup4

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Amazon Intelligence Demo</title>
+    <script src="https://unpkg.com/vue@3/dist/vue.global.prod.js"></script>
+    <style>
+        button.active { font-weight: bold; }
+        textarea { width: 300px; height: 80px; }
+    </style>
+</head>
+<body>
+<div id="app">
+    <h1>Amazon Intelligence Demo</h1>
+    <div>
+        <button v-for="t in tabs" :key="t" :class="{active: active===t}" @click="active=t">{{ t }}</button>
+    </div>
+
+    <div v-if="active==='Competitor Monitor'">
+        <input v-model="compInput" placeholder="Enter ASIN or URL" />
+        <button @click="scrape">采集</button>
+        <pre>{{ result }}</pre>
+    </div>
+
+    <div v-if="active==='Review Analysis'">
+        <textarea v-model="reviewInput" placeholder="One review per line"></textarea>
+        <button @click="analyzeReview">分析</button>
+        <pre>{{ reviewResult }}</pre>
+    </div>
+
+    <div v-if="active==='Listing Optimizer'">
+        <input v-model="listingTitle" placeholder="Listing Title" />
+        <button @click="optimizeListing">优化</button>
+        <pre>{{ optimizeResult }}</pre>
+    </div>
+
+    <div v-if="active==='Customer Service'">
+        <input v-model="question" placeholder="Customer question" />
+        <button @click="askService">回复</button>
+        <pre>{{ serviceResult }}</pre>
+    </div>
+</div>
+<script>
+const { createApp } = Vue;
+createApp({
+    data() {
+        return {
+            tabs: ['Competitor Monitor','Review Analysis','Listing Optimizer','Customer Service'],
+            active: 'Competitor Monitor',
+            compInput: '',
+            reviewInput: '',
+            listingTitle: '',
+            question: '',
+            result: {},
+            reviewResult: {},
+            optimizeResult: {},
+            serviceResult: {}
+        };
+    },
+    methods: {
+        async scrape() {
+            const params = new URLSearchParams();
+            if (this.compInput.startsWith('http')) {
+                params.append('url', this.compInput);
+            } else {
+                params.append('asin', this.compInput);
+            }
+            const res = await fetch('/api/scrape?' + params.toString());
+            this.result = await res.json();
+        },
+        async analyzeReview() {
+            const res = await fetch('/api/review_analysis', {
+                method: 'POST',
+                headers: {'Content-Type':'application/json'},
+                body: JSON.stringify({reviews: this.reviewInput.split('\n').filter(Boolean)})
+            });
+            this.reviewResult = await res.json();
+        },
+        async optimizeListing() {
+            const res = await fetch('/api/listing_optimizer', {
+                method: 'POST',
+                headers: {'Content-Type':'application/json'},
+                body: JSON.stringify({title: this.listingTitle})
+            });
+            this.optimizeResult = await res.json();
+        },
+        async askService() {
+            const res = await fetch('/api/customer_service', {
+                method: 'POST',
+                headers: {'Content-Type':'application/json'},
+                body: JSON.stringify({question: this.question})
+            });
+            this.serviceResult = await res.json();
+        }
+    }
+}).mount('#app');
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add mock `CustomerServiceAgent`, `ListingOptimizerAgent`, and `ReviewAnalysisAgent`
- expose new POST endpoints in FastAPI app
- expand Vue frontend with four tabs for the agents
- document endpoints and tabs in README

## Testing
- `python3 -m py_compile backend/main.py backend/agents/*.py`
- `pip install -r backend/requirements.txt`
- `PYTHONPATH=backend uvicorn backend.main:app --port 8002 --log-level warning &` plus sample `curl` requests

------
https://chatgpt.com/codex/tasks/task_e_685283481a7883329432e325cad691e2