### PR TITLE
Add keyword search analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # AI Demo Project
 
-This repository contains a minimal demonstration of an Amazon intelligence toolkit. It exposes four mock services representing the project agents:
-CustomerServiceAgent, ListingOptimizerAgent, ReviewAnalysisAgent and CompetitorMonitorAgent. The Competitor Monitor feature accepts an ASIN or URL and returns structured listing information.
+This repository contains a minimal demonstration of an Amazon intelligence toolkit. It exposes several mock services representing the project agents:
+CustomerServiceAgent, ListingOptimizerAgent, ReviewAnalysisAgent, CompetitorMonitorAgent and a simple keyword analyzer. The Competitor Monitor feature accepts an ASIN or URL and returns structured listing information.
 
 ## Backend
 - Python `FastAPI` server located in `backend/`
@@ -9,6 +9,7 @@ CustomerServiceAgent, ListingOptimizerAgent, ReviewAnalysisAgent and CompetitorM
 - Endpoint `POST /api/customer_service` returns a simple reply
 - Endpoint `POST /api/listing_optimizer` returns optimized title data
 - Endpoint `POST /api/review_analysis` returns a review summary
+- Endpoint `POST /api/analyze_keyword` returns search results and a basic analysis
 
 
 ### Running
@@ -19,11 +20,13 @@ uvicorn backend.main:app --reload
 The backend also serves the Vue3 frontend.
 
 ## Frontend
-- Vue3 app (`frontend/index.html`) provides four tabs matching the agents
+- Vue3 app (`frontend/index.html`) provides tabs matching the agents including a keyword search interface
 - Basic styling is provided using the Bootstrap 5 CDN
 - Each tab sends a request to the corresponding API and shows the JSON reply
 
 
 Open `http://127.0.0.1:8000` after starting the backend to use the demo.
+
+Select the **Keyword Search** tab to input a term and view the analysis JSON.
 
 *Note*: Due to environment restrictions, the demo uses a static sample HTML file instead of live Amazon requests.

--- a/backend/agents/keyword_search.py
+++ b/backend/agents/keyword_search.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from statistics import mean
+from typing import List, Dict, Any
+
+
+@dataclass
+class SearchResult:
+    asin: str
+    title: str | None = None
+    price: float | None = None
+    rating: float | None = None
+    reviews: int | None = None
+    brand: str | None = None
+    image: str | None = None
+    is_prime: bool | None = None
+    position: int | None = None
+
+
+class AmazonScraper:
+    """Fetch Amazon search results. Uses a local JSON sample for the demo."""
+
+    sample_file = Path(__file__).resolve().parent / "sample_search.json"
+
+    def search_products(self, keyword: str, marketplace: str = "amazon.de") -> List[SearchResult]:
+        """Return a list of SearchResult objects."""
+        try:
+            data = json.loads(self.sample_file.read_text(encoding="utf-8"))
+        except FileNotFoundError:
+            return []
+
+        products: List[SearchResult] = []
+        for item in data.get("organic_results", []):
+            result = SearchResult(
+                asin=item.get("asin", ""),
+                title=item.get("title"),
+                price=item.get("price", {}).get("value"),
+                rating=item.get("rating"),
+                reviews=item.get("reviews"),
+                brand=item.get("brand"),
+                image=item.get("thumbnail"),
+                is_prime=item.get("is_prime"),
+                position=item.get("position"),
+            )
+            products.append(result)
+        return products
+
+    def get_product_details(self, asin: str) -> Dict[str, Any]:
+        """Return extra details for a product. For the demo it returns an empty dict."""
+        return {}
+
+
+class AIAnalyzer:
+    """Mock analyzer that aggregates basic statistics from search results."""
+
+    def analyze_listings(self, products: List[SearchResult]) -> Dict[str, Any]:
+        if not products:
+            return {}
+
+        prices = [p.price for p in products if p.price is not None]
+        avg_price = round(mean(prices), 2) if prices else None
+
+        brand_count: Dict[str, int] = {}
+        for p in products:
+            if p.brand:
+                brand_count[p.brand] = brand_count.get(p.brand, 0) + 1
+
+        top_brand = None
+        if brand_count:
+            top_brand = max(brand_count.items(), key=lambda x: x[1])[0]
+
+        return {
+            "total_products": len(products),
+            "average_price": avg_price,
+            "top_brand": top_brand,
+        }

--- a/backend/agents/sample_search.json
+++ b/backend/agents/sample_search.json
@@ -1,0 +1,7 @@
+{
+  "organic_results": [
+    {"asin": "B000111", "title": "Sample Product A", "price": {"value": 19.99}, "rating": 4.5, "reviews": 120, "brand": "BrandA", "thumbnail": "imageA.jpg", "is_prime": true, "position": 1},
+    {"asin": "B000222", "title": "Sample Product B", "price": {"value": 25.50}, "rating": 4.0, "reviews": 90, "brand": "BrandB", "thumbnail": "imageB.jpg", "is_prime": false, "position": 2},
+    {"asin": "B000333", "title": "Sample Product C", "price": {"value": 15.00}, "rating": 3.8, "reviews": 50, "brand": "BrandA", "thumbnail": "imageC.jpg", "is_prime": true, "position": 3}
+  ]
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -26,6 +26,14 @@
         <pre class="bg-white p-3 border rounded">{{ result }}</pre>
     </div>
 
+    <div v-if="active==='Keyword Search'" class="mb-3">
+        <div class="input-group mb-2">
+            <input v-model="keywordInput" placeholder="Enter keyword" class="form-control" />
+            <button @click="analyzeKeyword" class="btn btn-primary">分析</button>
+        </div>
+        <pre class="bg-white p-3 border rounded">{{ keywordResult }}</pre>
+    </div>
+
     <div v-if="active==='Review Analysis'" class="mb-3">
         <textarea v-model="reviewInput" placeholder="One review per line" class="form-control mb-2"></textarea>
         <button @click="analyzeReview" class="btn btn-primary mb-2">分析</button>
@@ -53,13 +61,15 @@ const { createApp } = Vue;
 createApp({
     data() {
         return {
-            tabs: ['Competitor Monitor','Review Analysis','Listing Optimizer','Customer Service'],
+            tabs: ['Competitor Monitor','Keyword Search','Review Analysis','Listing Optimizer','Customer Service'],
             active: 'Competitor Monitor',
             compInput: '',
+            keywordInput: '',
             reviewInput: '',
             listingTitle: '',
             question: '',
             result: {},
+            keywordResult: {},
             reviewResult: {},
             optimizeResult: {},
             serviceResult: {}
@@ -75,6 +85,14 @@ createApp({
             }
             const res = await fetch('/api/scrape?' + params.toString());
             this.result = await res.json();
+        },
+        async analyzeKeyword() {
+            const res = await fetch('/api/analyze_keyword', {
+                method: 'POST',
+                headers: {'Content-Type':'application/json'},
+                body: JSON.stringify({keyword: this.keywordInput})
+            });
+            this.keywordResult = await res.json();
         },
         async analyzeReview() {
             const res = await fetch('/api/review_analysis', {


### PR DESCRIPTION
## Summary
- implement `AmazonScraper` and `AIAnalyzer` for keyword search
- expose `/api/analyze_keyword` FastAPI endpoint
- update Vue frontend with new Keyword Search tab
- document the new endpoint and usage

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6854c7fd2fc083329b3a8127bbfe4227