### PR TITLE
Integrate SerpAPI for keyword search

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -3,6 +3,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
 from pydantic import BaseModel
 from pathlib import Path
+import os
 
 from .agents.competitor_monitor import CompetitorMonitorAgent
 from .agents.customer_service import CustomerServiceAgent
@@ -25,7 +26,8 @@ competitor_agent = CompetitorMonitorAgent()
 customer_agent = CustomerServiceAgent()
 optimizer_agent = ListingOptimizerAgent()
 review_agent = ReviewAnalysisAgent()
-keyword_scraper = AmazonScraper()
+SERPAPI_KEY = os.getenv("SERPAPI_KEY")
+keyword_scraper = AmazonScraper(api_key=SERPAPI_KEY)
 ai_analyzer = AIAnalyzer()
 
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 requests
 beautifulsoup4
+serpapi


### PR DESCRIPTION
## Summary
- add `serpapi` dependency
- use SerpAPI in `AmazonScraper` when API key is provided
- pass `SERPAPI_KEY` from environment when creating the scraper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855082396448332882c8e3ae190b520